### PR TITLE
docs(demo): alertValue demo only attaches when correct select in DOM #57

### DIFF
--- a/demo/alertValue.js
+++ b/demo/alertValue.js
@@ -1,6 +1,10 @@
 setTimeout(() => {
-  document.querySelector('#valueAlert').addEventListener('selectedOption', (evt) => {
-    console.warn('Value selected:', evt.target.optionSelected.value);
-    alert(`Value selected: ${evt.target.optionSelected.value}`);
-  });
+  let selectValueAlertEl = document.querySelector('auro-select#valueAlert');
+
+  if (selectValueAlertEl) {
+    selectValueAlertEl.addEventListener('selectedOption', () => {
+      console.warn('Value selected:', selectValueAlertEl.optionSelected.value);
+      alert(`Value selected: ${selectValueAlertEl.optionSelected.value}`);
+    });
+  }
 }, 500);

--- a/demo/apiExamples.md
+++ b/demo/apiExamples.md
@@ -448,10 +448,14 @@ The following example listens for the `selectOption` custom event from the `<aur
 
 ```js
 setTimeout(() => {
-  document.querySelector('#valueAlert').addEventListener('selectedOption', (evt) => {
-    console.warn('Value selected:', evt.target.optionSelected.value);
-    alert(`Value selected: ${evt.target.optionSelected.value}`);
-  });
+  let selectValueAlertEl = document.querySelector('auro-select#valueAlert');
+
+  if (selectValueAlertEl) {
+    selectValueAlertEl.addEventListener('selectedOption', () => {
+      console.warn('Value selected:', selectValueAlertEl.optionSelected.value);
+      alert(`Value selected: ${selectValueAlertEl.optionSelected.value}`);
+    });
+  }
 }, 500);
 ```
 <!-- AURO-GENERATED-CONTENT:END -->


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #57

## Summary:

This change makes the alertValue.js demo only try to attach the eventlistener if the correct select element is in the DOM.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
