### PR TITLE
docs(icons): fixed typos in icon references

### DIFF
--- a/apiExamples/withIcons.html
+++ b/apiExamples/withIcons.html
@@ -7,10 +7,10 @@
       <auro-icon label customColor category="health" name="covid-test">Covid Test</auro-icon>
     </auro-menuoption>
     <auro-menuoption value="health">
-      <auro-icon label customColor category="health" name="Health">Health</auro-icon>
+      <auro-icon label customColor category="health" name="health">Health</auro-icon>
     </auro-menuoption>
     <auro-menuoption value="mask">
-      <auro-icon label customColor category="health" name="Mask">Mask</auro-icon>
+      <auro-icon label customColor category="health" name="mask">Mask</auro-icon>
     </auro-menuoption>
     <auro-menuoption value="spraybottle">
       <auro-icon label customColor category="health" name="spraybottle">Spray Bottle</auro-icon>

--- a/demo/demo.md
+++ b/demo/demo.md
@@ -81,10 +81,10 @@ A baseline `<auro-select>` using `<auro-menu>` and `<auro-menuoption>` elements.
         <auro-icon label customColor category="health" name="covid-test">Covid Test</auro-icon>
       </auro-menuoption>
       <auro-menuoption value="health">
-        <auro-icon label customColor category="health" name="Health">Health</auro-icon>
+        <auro-icon label customColor category="health" name="health">Health</auro-icon>
       </auro-menuoption>
       <auro-menuoption value="mask">
-        <auro-icon label customColor category="health" name="Mask">Mask</auro-icon>
+        <auro-icon label customColor category="health" name="mask">Mask</auro-icon>
       </auro-menuoption>
       <auro-menuoption value="spraybottle">
         <auro-icon label customColor category="health" name="spraybottle">Spray Bottle</auro-icon>
@@ -108,10 +108,10 @@ A baseline `<auro-select>` using `<auro-menu>` and `<auro-menuoption>` elements.
       <auro-icon label customColor category="health" name="covid-test">Covid Test</auro-icon>
     </auro-menuoption>
     <auro-menuoption value="health">
-      <auro-icon label customColor category="health" name="Health">Health</auro-icon>
+      <auro-icon label customColor category="health" name="health">Health</auro-icon>
     </auro-menuoption>
     <auro-menuoption value="mask">
-      <auro-icon label customColor category="health" name="Mask">Mask</auro-icon>
+      <auro-icon label customColor category="health" name="mask">Mask</auro-icon>
     </auro-menuoption>
     <auro-menuoption value="spraybottle">
       <auro-icon label customColor category="health" name="spraybottle">Spray Bottle</auro-icon>


### PR DESCRIPTION
# Alaska Airlines Pull Request

This fixes case-sensitivity typos in a couple auro-icon references in one of the documentation examples.

<img width="505" alt="Screen Shot 2022-07-05 at 9 39 54 AM" src="https://user-images.githubusercontent.com/6138182/177377589-40ea7d9a-b87d-4a60-8d6e-bd1b8c669944.png">

**Fixes:** #78 

## Type of change:

Please delete options that are not relevant.

- [X] Other (please elaborate)

Minor docs update

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
