### PR TITLE
Make screenreader commentary follow HTML5 workflow

### DIFF
--- a/src/auro-select.js
+++ b/src/auro-select.js
@@ -205,6 +205,8 @@ class AuroSelect extends LitElement {
         this.dropdown.hide();
       }
     });
+
+    this.labelForSr();
   }
 
   /**
@@ -319,6 +321,34 @@ class AuroSelect extends LitElement {
     if (changedProperties.has('value')) {
       this.menu.value = this.value;
     }
+  }
+
+  /**
+   * Handles reading of auro-select by screenreaders.
+   * @private
+   * @returns {void}
+   */
+  labelForSr() {
+    const placeholderLabel = document.createElement("div");
+    const textId = "label";
+
+    placeholderLabel.setAttribute("id", textId);
+    placeholderLabel.setAttribute("aria-live", "polite");
+    placeholderLabel.classList.add("util_displayHiddenVisually");
+
+    this.addEventListener('focus', () => {
+      document.body.appendChild(placeholderLabel);
+
+      if (!this.optionSelected) {
+        document.getElementById(textId).innerHTML = this.placeholder;
+      } else {
+        document.getElementById(textId).innerHTML = `${this.optionSelected.innerText}, ${this.placeholder}`;
+      }
+    });
+
+    this.addEventListener('blur', () => {
+      document.body.removeChild(document.getElementById(textId));
+    });
   }
 
   // When using auroElement, use the following attribute and function when hiding content from screen readers.

--- a/src/auro-select.js
+++ b/src/auro-select.js
@@ -119,6 +119,8 @@ class AuroSelect extends LitElement {
   configureMenu() {
     this.menu = this.querySelector('auro-menu');
 
+    this.menu.setAttribute('aria-hidden', 'true');
+
     this.generateOptionsArray();
 
     this.menu.addEventListener('auroMenu-ready', () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #111 

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

Changes include:
* Setting the `aria-hidden` attribute on `auro-menu` to be true in order to stop all menu options from being read when `auro-select` gains focus
* Adding a new method that forces the screenreader to read the placeholder text like a label when `auro-select` gains focus

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
