### PR TITLE
fix: to use disabled design token instead of opacity

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -43,7 +43,7 @@
 
 :host([disabled]) {
   * {
-    opacity: .7;
+    color: var(--ds-color-text-disabled-default, $ds-color-text-disabled-default);
     user-select: none;
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

This change make `auro-select` use the same token for disabled that other form components use instead of relying on opacity to get a similar disabled effect.

**Resolves:** #185 

## Summary:

This will allow theming since we will use the standard token for disabled states.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
