### PR TITLE
AURO MIGRATION PR: Update dropdown to version 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@aurodesignsystem/auro-select",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-select",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/auro-dropdown": "^3.2.1",
+        "@aurodesignsystem/auro-dropdown": "^3.2.2",
         "@aurodesignsystem/auro-formvalidation": "^1.0.4",
         "@aurodesignsystem/auro-library": "^3.0.2",
         "@aurodesignsystem/auro-menu": "^4.2.0",
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-dropdown": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-dropdown/-/auro-dropdown-3.2.1.tgz",
-      "integrity": "sha512-ZvYQq16rMHsrxqLqGXl5GPit/MA0OkGvh4XaIJv9k60SfgWzxWoFcULsnBu/30+LzxI3Uu5ubK+0yCOOJmLHfg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-dropdown/-/auro-dropdown-3.2.2.tgz",
+      "integrity": "sha512-fPsHmnI15GNPEOSkMjbEk0+aL6O2z2az3e0uMt++8l83dGH0GSENgCPnl47FKzOVZX0+6pWVoTAxVSVANVrEwQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": "^18.x || ^20.x"
   },
   "dependencies": {
-    "@aurodesignsystem/auro-dropdown": "^3.2.1",
+    "@aurodesignsystem/auro-dropdown": "^3.2.2",
     "@aurodesignsystem/auro-formvalidation": "^1.0.4",
     "@aurodesignsystem/auro-library": "^3.0.2",
     "@aurodesignsystem/auro-menu": "^4.2.0",

--- a/src/dropdownVersion.js
+++ b/src/dropdownVersion.js
@@ -1,1 +1,1 @@
-export default '3.2.1'
+export default '3.2.2'


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update `@aurodesignsystem/auro-dropdown` dependency to 3.2.2.